### PR TITLE
Connect frontend dashboards to database

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -60,6 +60,15 @@ function decodeJWT(token){
 }
 function softAttachUser(req, _res, next){
   try{ const t = extractToken(req); if (t) req.user = decodeJWT(t) }catch{}
+  if (req.user){
+    const actualRole = resolveRole(req.user)
+    if (actualRole) req.user.role = actualRole
+    const stored = getStoredUser(req.user)
+    if (stored){
+      if (stored.name) req.user.name = stored.name
+      if (stored.providerPlayerId) req.user.providerPlayerId = stored.providerPlayerId
+    }
+  }
   next()
 }
 function requireAuth(req, res, next){
@@ -69,7 +78,14 @@ function requireRole(...roles){
   const allowed = (Array.isArray(roles[0]) ? roles[0] : roles).map(x=>String(x).toUpperCase())
   return (req, res, next) => {
     try{ const t = extractToken(req); const u = decodeJWT(t); req.user = u }catch{ return res.status(401).json({ error:'Unauthorized' }) }
-    const r = String(req.user?.role||'').toUpperCase()
+    let r = String(req.user?.role||'').toUpperCase()
+    if (allowed.length>0 && !allowed.includes(r)){
+      const actual = resolveRole(req.user)
+      if (actual) {
+        req.user.role = actual
+        r = actual
+      }
+    }
     if (allowed.length>0 && !allowed.includes(r)) return res.status(403).json({ error:'Forbidden' })
     return next()
   }
@@ -116,6 +132,175 @@ function seedMemUsers(){
 }
 seedMemUsers()
 
+const randomId = () => Math.random().toString(36).slice(2, 10)
+const nowIso = () => new Date().toISOString()
+
+function boolish(value){
+  if (typeof value === 'boolean') return value
+  if (typeof value === 'number') return value !== 0
+  if (typeof value === 'string') return ['1','true','yes','on'].includes(value.trim().toLowerCase())
+  return false
+}
+
+function normalizeProvider(row, fallbackId=null, fallbackName='Provider'){
+  const src = row || {}
+  return {
+    id: src.id || fallbackId || null,
+    name: src.name || fallbackName || 'Provider',
+    role: src.role || 'PROVIDER',
+    rating: Number(src.rating ?? 0),
+    jobs: Number(src.jobs ?? 0),
+    bio: src.bio || '',
+    location: src.location || '',
+    website: src.website || '',
+    phone: src.phone || '',
+    specialties: src.specialties || '',
+    hourlyRate: Number(src.hourlyRate ?? 0),
+    availability: src.availability || '',
+    experienceYears: Number(src.experienceYears ?? 0),
+    languages: src.languages || '',
+    certifications: src.certifications || '',
+    socialTwitter: src.socialTwitter || '',
+    socialInstagram: src.socialInstagram || '',
+    portfolio: src.portfolio || '',
+    sessionLength: src.sessionLength || '',
+    editedPhotos: Number(src.editedPhotos ?? 0),
+    delivery: src.delivery || '',
+    turnaround: src.turnaround || '',
+    onLocation: boolish(src.onLocation),
+    studioAvailable: boolish(src.studioAvailable),
+    travelRadius: src.travelRadius || '',
+    styles: src.styles || '',
+    equipment: src.equipment || '',
+  }
+}
+
+function getStoredUser(decoded){
+  const id = decoded?.sub || decoded?.id || ''
+  const email = String(decoded?.email || '').trim().toLowerCase()
+  if (db?.available){
+    try{
+      if (id){
+        const byId = db.prepare('SELECT * FROM users WHERE id=?').get(id)
+        if (byId) return byId
+      }
+      if (email){
+        const byEmail = db.prepare('SELECT * FROM users WHERE lower(email)=lower(?)').get(email)
+        if (byEmail) return byEmail
+      }
+    }catch{}
+  } else {
+    if (email && usersMem.has(email)) return { ...usersMem.get(email) }
+    if (id){
+      for (const value of usersMem.values()){
+        if (value.id === id) return { ...value }
+      }
+    }
+  }
+  return null
+}
+
+function resolveRole(decoded){
+  const stored = getStoredUser(decoded)
+  if (stored && stored.role) return String(stored.role).toUpperCase()
+  return ''
+}
+
+function fetchProviderRow(providerId){
+  if (!providerId || !db?.available) return null
+  try{ return db.prepare('SELECT * FROM players WHERE id=?').get(providerId) }catch{ return null }
+}
+
+function upsertProvider(providerId, payload={}, fallbackName='Provider'){
+  if (!providerId || !db?.available) return null
+  const existing = fetchProviderRow(providerId) || {}
+  const onLocation = boolish(payload.onLocation ?? existing.onLocation)
+  const studioAvailable = boolish(payload.studioAvailable ?? existing.studioAvailable)
+  const row = {
+    id: providerId,
+    name: payload.name || existing.name || fallbackName || 'Provider',
+    role: 'PROVIDER',
+    rating: Number(payload.rating ?? existing.rating ?? 0),
+    jobs: Number(payload.jobs ?? existing.jobs ?? 0),
+    bio: payload.bio ?? existing.bio ?? '',
+    location: payload.location ?? existing.location ?? '',
+    website: payload.website ?? existing.website ?? '',
+    phone: payload.phone ?? existing.phone ?? '',
+    specialties: payload.specialties ?? existing.specialties ?? '',
+    hourlyRate: Number(payload.hourlyRate ?? existing.hourlyRate ?? 0),
+    availability: payload.availability ?? existing.availability ?? '',
+    experienceYears: Number(payload.experienceYears ?? existing.experienceYears ?? 0),
+    languages: payload.languages ?? existing.languages ?? '',
+    certifications: payload.certifications ?? existing.certifications ?? '',
+    socialTwitter: payload.socialTwitter ?? existing.socialTwitter ?? '',
+    socialInstagram: payload.socialInstagram ?? existing.socialInstagram ?? '',
+    portfolio: payload.portfolio ?? existing.portfolio ?? '',
+    sessionLength: payload.sessionLength ?? existing.sessionLength ?? '',
+    editedPhotos: Number(payload.editedPhotos ?? existing.editedPhotos ?? 0),
+    delivery: payload.delivery ?? existing.delivery ?? '',
+    turnaround: payload.turnaround ?? existing.turnaround ?? '',
+    onLocation: onLocation ? 1 : 0,
+    studioAvailable: studioAvailable ? 1 : 0,
+    travelRadius: payload.travelRadius ?? existing.travelRadius ?? '',
+    styles: payload.styles ?? existing.styles ?? '',
+    equipment: payload.equipment ?? existing.equipment ?? '',
+  }
+  db.prepare(`
+    INSERT INTO players (id,name,role,rating,jobs,bio,location,website,phone,specialties,hourlyRate,availability,experienceYears,languages,certifications,socialTwitter,socialInstagram,portfolio,sessionLength,editedPhotos,delivery,turnaround,onLocation,studioAvailable,travelRadius,styles,equipment)
+    VALUES (@id,@name,@role,@rating,@jobs,@bio,@location,@website,@phone,@specialties,@hourlyRate,@availability,@experienceYears,@languages,@certifications,@socialTwitter,@socialInstagram,@portfolio,@sessionLength,@editedPhotos,@delivery,@turnaround,@onLocation,@studioAvailable,@travelRadius,@styles,@equipment)
+    ON CONFLICT(id) DO UPDATE SET
+      name=excluded.name,
+      role=excluded.role,
+      rating=excluded.rating,
+      jobs=excluded.jobs,
+      bio=excluded.bio,
+      location=excluded.location,
+      website=excluded.website,
+      phone=excluded.phone,
+      specialties=excluded.specialties,
+      hourlyRate=excluded.hourlyRate,
+      availability=excluded.availability,
+      experienceYears=excluded.experienceYears,
+      languages=excluded.languages,
+      certifications=excluded.certifications,
+      socialTwitter=excluded.socialTwitter,
+      socialInstagram=excluded.socialInstagram,
+      portfolio=excluded.portfolio,
+      sessionLength=excluded.sessionLength,
+      editedPhotos=excluded.editedPhotos,
+      delivery=excluded.delivery,
+      turnaround=excluded.turnaround,
+      onLocation=excluded.onLocation,
+      studioAvailable=excluded.studioAvailable,
+      travelRadius=excluded.travelRadius,
+      styles=excluded.styles,
+      equipment=excluded.equipment
+  `).run(row)
+  return row
+}
+
+function ensureProviderForUser(userRow){
+  if (!userRow) return null
+  if (userRow.providerPlayerId) return userRow.providerPlayerId
+  const providerId = 'p_' + randomId()
+  const name = userRow.name || (userRow.email ? userRow.email.split('@')[0] : 'Provider')
+  if (db?.available){
+    try{
+      upsertProvider(providerId, { name }, name)
+      db.prepare('UPDATE users SET providerPlayerId=?, role=? WHERE id=?').run(providerId, 'TRADER', userRow.id)
+    }catch{}
+  } else {
+    const email = String(userRow.email||'').toLowerCase()
+    if (email && usersMem.has(email)){
+      const next = { ...usersMem.get(email), providerPlayerId: providerId, role: 'TRADER' }
+      usersMem.set(email, next)
+    }
+  }
+  userRow.providerPlayerId = providerId
+  userRow.role = 'TRADER'
+  return providerId
+}
+
 // Return current user from req.user (if a JWT middleware set it) or from demo session
 app.get('/api/me', (req, res) => {
   try{
@@ -123,8 +308,17 @@ app.get('/api/me', (req, res) => {
     if (!u) return res.status(401).json({ error:'No session' })
     const id = u.id || u.sub || null
     const email = u.email || null
-    const role = u.role || null
-    return res.json({ id, email, role })
+    let role = u.role || null
+    let name = u.name || null
+    let providerPlayerId = u.providerPlayerId || null
+    const stored = getStoredUser(u)
+    if (stored){
+      if (stored.role) role = stored.role
+      if (stored.name) name = stored.name
+      if (stored.providerPlayerId) providerPlayerId = stored.providerPlayerId
+    }
+    if (role) role = String(role).toUpperCase()
+    return res.json({ id, email, role, name, providerPlayerId })
   }catch{ return res.status(401).json({ error:'No session' }) }
 })
 
@@ -413,6 +607,159 @@ app.put('/api/trader/listings/:id', requireAuth, (req, res) => {
   res.json(found)
 })
 
+app.get('/api/user/favorites', requireAuth, (req, res) => {
+  try{
+    const decoded = req.user || {}
+    const stored = getStoredUser(decoded)
+    const userId = stored?.id || decoded?.sub || decoded?.id || ''
+    if (db?.available && userId){
+      const favRows = db.prepare('SELECT providerId FROM favorites WHERE userId=?').all(userId)
+      const interactionRows = db.prepare('SELECT providerId, COUNT(*) AS cnt FROM interactions WHERE userId=? GROUP BY providerId').all(userId)
+      const counts = new Map()
+      for (const row of interactionRows){
+        const pid = String(row.providerId || '')
+        if (!pid) continue
+        counts.set(pid, Number(row.cnt || 0))
+      }
+      const ids = new Set([ ...counts.keys(), ...favRows.map(r => String(r.providerId || '')) ])
+      const stmt = db.prepare('SELECT * FROM players WHERE id=?')
+      const results = []
+      for (const pid of ids){
+        if (!pid) continue
+        let providerRow = null
+        try{ providerRow = stmt.get(pid) }catch{}
+        const provider = normalizeProvider(providerRow, pid)
+        results.push({ provider, count: counts.get(pid) || 0 })
+      }
+      if (results.length === 0){
+        try{
+          const top = db.prepare("SELECT * FROM players WHERE role='PROVIDER' LIMIT 5").all()
+          for (const row of top){ results.push({ provider: normalizeProvider(row, row.id), count: counts.get(row.id) || 0 }) }
+        }catch{}
+      }
+      results.sort((a,b) => (b.count||0) - (a.count||0))
+      return res.json(results)
+    }
+  }catch(e){ if (process.env.NODE_ENV !== 'production') console.error('favorites error', e) }
+  const fallback = (Array.isArray(favorites) ? favorites : []).map(f => {
+    const pid = f.providerId || f.id || null
+    const provider = normalizeProvider(f.provider || f, pid, f.name || (f.provider && f.provider.name) || 'Provider')
+    return { provider, count: Number(f.count || 0) }
+  })
+  res.json(fallback)
+})
+
+app.get('/api/user/history', requireAuth, (req, res) => {
+  const decoded = req.user || {}
+  const stored = getStoredUser(decoded)
+  const userId = stored?.id || decoded?.sub || decoded?.id || ''
+  try{
+    if (db?.available && userId){
+      const rows = db.prepare(`
+        SELECT i.id, i.providerId, i.note, i.at, i.amount, i.listingId, p.name AS providerName
+        FROM interactions i
+        LEFT JOIN players p ON p.id = i.providerId
+        WHERE i.userId = ?
+        ORDER BY i.at DESC
+        LIMIT 100
+      `).all(userId)
+      return res.json(rows.map(r => ({
+        id: r.id,
+        providerId: r.providerId,
+        providerName: r.providerName || 'Provider',
+        note: r.note || '',
+        at: r.at || nowIso(),
+        amount: Number(r.amount || 0),
+        listingId: r.listingId || null,
+      })))
+    }
+  }catch(e){ if (process.env.NODE_ENV !== 'production') console.error('user history error', e) }
+  const uid = decoded?.sub || decoded?.id || null
+  const fallback = (Array.isArray(history) ? history : []).filter(h => !uid || !h.userId || h.userId === uid).map(h => ({
+    id: h.id,
+    providerId: h.providerId || h.traderId || null,
+    providerName: h.providerName || h.traderName || 'Provider',
+    note: h.note || h.service || '',
+    at: h.at || h.createdAt || nowIso(),
+    amount: Number(h.amount || 0),
+    listingId: h.listingId || null,
+  }))
+  res.json(fallback)
+})
+
+app.post('/api/become-provider', requireAuth, (req, res) => {
+  try{
+    const decoded = req.user || {}
+    const stored = getStoredUser(decoded)
+    if (stored){
+      const userRow = { ...stored }
+      const providerId = ensureProviderForUser(userRow)
+      const updated = getStoredUser({ ...decoded, sub: userRow.id, id: userRow.id, email: userRow.email }) || userRow
+      const token = signJWT({ sub: userRow.id, email: updated.email || userRow.email, role: 'TRADER' })
+      const cookieOpts = { httpOnly:true, sameSite:'lax', secure: isProd, path:'/' }
+      res.cookie('token', token, cookieOpts)
+      return res.json({ ok:true, token, user:{ id: userRow.id, name: updated.name || userRow.name, email: updated.email || userRow.email, role:'TRADER', providerPlayerId: providerId } })
+    }
+  }catch(e){ if (process.env.NODE_ENV !== 'production') console.error('become-provider', e) }
+  const email = String(req.user?.email||'').toLowerCase()
+  if (email && usersMem.has(email)){
+    const current = { ...usersMem.get(email) }
+    current.role = 'TRADER'
+    if (!current.providerPlayerId) current.providerPlayerId = 'p_' + randomId()
+    usersMem.set(email, current)
+    const token = signJWT({ sub: current.id, email: current.email, role: 'TRADER' })
+    const cookieOpts = { httpOnly:true, sameSite:'lax', secure: isProd, path:'/' }
+    res.cookie('token', token, cookieOpts)
+    return res.json({ ok:true, token, user:{ id: current.id, name: current.name, email: current.email, role: current.role, providerPlayerId: current.providerPlayerId } })
+  }
+  res.status(400).json({ error:'User not found' })
+})
+
+app.post('/api/checkout', requireAuth, (req, res) => {
+  try{
+    const decoded = req.user || {}
+    const stored = getStoredUser(decoded)
+    const userId = stored?.id || decoded?.sub || decoded?.id || ''
+    if (!userId) return res.status(401).json({ error:'Unauthorized' })
+    const { amount=0, name='', email='', note='', listingId=null, providerId=null } = req.body||{}
+    const txId = 'tx_' + randomId()
+    const at = nowIso()
+    if (db?.available){
+      let actualProviderId = providerId ? String(providerId) : ''
+      let providerRow = actualProviderId ? fetchProviderRow(actualProviderId) : null
+      let listingRow = null
+      if (listingId){
+        try{ listingRow = db.prepare('SELECT * FROM listings WHERE id=?').get(listingId) }catch{}
+        if (listingRow){
+          if (!actualProviderId) actualProviderId = String(listingRow.providerId || '')
+          if (!providerRow) providerRow = fetchProviderRow(listingRow.providerId)
+        }
+      }
+      if (!actualProviderId){
+        if (providerRow && providerRow.id) actualProviderId = String(providerRow.id)
+        else return res.status(400).json({ error:'Provider required' })
+      }
+      if (!providerRow) providerRow = fetchProviderRow(actualProviderId)
+      const cleanNote = String(note || (listingRow?.title ? `Purchased ${listingRow.title}` : '') || '').slice(0, 400)
+      try{
+        db.prepare('INSERT INTO interactions (id,userId,providerId,listingId,at,note,amount) VALUES (?,?,?,?,?,?,?)').run(txId, userId, actualProviderId, listingId || null, at, cleanNote, Number(amount || 0))
+      }catch(err){
+        if (process.env.NODE_ENV !== 'production') console.error('checkout insert', err)
+        return res.status(500).json({ error:'Checkout failed' })
+      }
+      try{ db.prepare('INSERT OR IGNORE INTO favorites (userId, providerId) VALUES (?,?)').run(userId, actualProviderId) }catch{}
+      history.unshift({ id: txId, traderId: actualProviderId, traderName: providerRow?.name || 'Provider', service: listingRow?.title || 'Service', status:'paid', amount:Number(amount||0), at, userId, userName: name || stored?.name || email || stored?.email || 'You', note: cleanNote, providerId: actualProviderId, listingId })
+      return res.json({ ok:true, txId })
+    }
+  }catch(e){ if (process.env.NODE_ENV !== 'production') console.error('checkout error', e) }
+  const txId = 'tx_' + randomId()
+  const at = nowIso()
+  const body = req.body || {}
+  const fallbackNote = String(body.note || body.service || 'Purchase').slice(0, 200)
+  history.unshift({ id: txId, traderId: body.providerId || 'demo', traderName: 'Demo Trader', service: body.service || 'Service', status:'paid', amount:Number(body.amount || 0), at, userId: req.user?.sub || null, userName: body.name || 'You', note: fallbackNote, providerId: body.providerId || null, listingId: body.listingId || null })
+  res.json({ ok:true, txId })
+})
+
 // Reviews (in-memory demo)
 const providerReviews = new Map() // providerId -> [ {id, author, rating, text, at, userId} ]
 app.get('/api/providers/:id/reviews', (req, res) => {
@@ -470,28 +817,130 @@ app.post('/api/checkout/pay', requireAuth, (req, res) => {
 
 // Trader routes
 app.get('/api/trader/summary', requireRole('TRADER'), (req, res) => {
+  try{
+    const decoded = req.user || {}
+    const stored = getStoredUser(decoded)
+    const providerId = stored?.providerPlayerId || decoded?.providerPlayerId || null
+    if (db?.available && providerId){
+      const stats = db.prepare('SELECT COALESCE(SUM(amount),0) AS earnings, COUNT(*) AS orders, COUNT(DISTINCT userId) AS clients FROM interactions WHERE providerId=?').get(providerId)
+      const ratingRow = db.prepare('SELECT rating, jobs FROM players WHERE id=?').get(providerId) || {}
+      return res.json({
+        earnings: Number(stats?.earnings || 0),
+        orders: Number(stats?.orders || 0),
+        clients: Number(stats?.clients || 0),
+        rating: Number(ratingRow.rating || 0),
+        jobs: Number(ratingRow.jobs || 0),
+      })
+    }
+  }catch(e){ if (process.env.NODE_ENV !== 'production') console.error('trader summary', e) }
   res.json({ earnings: 12450.75, jobs: 36, rating: 4.8, clients: 22 })
 })
 app.get('/api/trader/history', requireRole('TRADER'), (req, res) => {
-  res.json(history.map(h => ({ id:h.id, userName:'You', service:h.service, status:h.status })))
+  try{
+    const decoded = req.user || {}
+    const stored = getStoredUser(decoded)
+    const providerId = stored?.providerPlayerId || decoded?.providerPlayerId || null
+    if (db?.available && providerId){
+      const rows = db.prepare(`
+        SELECT i.id, i.note, i.at, i.amount, u.name AS userName, u.email AS userEmail
+        FROM interactions i
+        LEFT JOIN users u ON u.id = i.userId
+        WHERE i.providerId = ?
+        ORDER BY i.at DESC
+        LIMIT 100
+      `).all(providerId)
+      return res.json(rows.map(r => ({
+        id: r.id,
+        userName: r.userName || r.userEmail || 'Customer',
+        note: r.note || '',
+        at: r.at || nowIso(),
+        amount: Number(r.amount || 0),
+      })))
+    }
+  }catch(e){ if (process.env.NODE_ENV !== 'production') console.error('trader history', e) }
+  const providerId = req.user?.providerPlayerId || null
+  const fallback = (Array.isArray(history) ? history : []).filter(h => {
+    if (!providerId) return true
+    const pid = h.providerId || h.traderId
+    return String(pid||'') === String(providerId||'')
+  }).map(h => ({
+    id: h.id,
+    userName: h.userName || h.customerName || h.user || 'Customer',
+    note: h.note || h.service || '',
+    at: h.at || h.createdAt || nowIso(),
+    amount: Number(h.amount || 0),
+  }))
+  res.json(fallback)
 })
 // Per-user in-memory trader profiles to avoid cross-user leakage
 const traderProfiles = new Map() // key: user.sub/email -> profile object
-app.get('/api/trader/profile', requireAuth, (req, res) => {
-  const key = req.user?.sub || req.user?.email || 'anon'
+function respondWithTraderProfile(req, res){
+  const decoded = req.user || {}
+  const stored = getStoredUser(decoded)
+  if (db?.available && stored){
+    const providerId = stored.providerPlayerId || null
+    const providerRow = providerId ? fetchProviderRow(providerId) : null
+    const baseName = stored.name || decoded.name || (stored.email ? stored.email.split('@')[0] : 'Provider')
+    const provider = normalizeProvider(providerRow, providerId, baseName)
+    const full = (stored.name || decoded.name || '').trim()
+    const parts = full ? full.split(/\s+/) : []
+    const firstName = parts[0] || ''
+    const lastName = parts.slice(1).join(' ')
+    return res.json({ ...provider, firstName, lastName, id: provider.id })
+  }
+  const key = decoded.sub || decoded.email || 'anon'
   const profile = traderProfiles.get(key) || {}
-  const full = (req.user?.name||'').trim()
+  const full = (decoded.name||'').trim()
   const firstName = profile.firstName || (full ? full.split(/\s+/)[0] : '')
   const lastName = profile.lastName || (full ? full.split(/\s+/).slice(1).join(' ') : '')
-  res.json({ ...profile, firstName, lastName, id: profile.providerId || null })
-})
-app.put('/api/trader/profile', requireAuth, (req, res) => {
-  const key = req.user?.sub || req.user?.email || 'anon'
+  return res.json({ ...normalizeProvider(profile, profile.providerId || null, profile.name || 'Provider'), firstName, lastName, id: profile.providerId || null })
+}
+app.get('/api/trader/profile', requireAuth, respondWithTraderProfile)
+function writeTraderProfile(req, res){
+  const decoded = req.user || {}
+  const stored = getStoredUser(decoded)
+  if (db?.available && stored){
+    const userRow = { ...stored }
+    const providerId = ensureProviderForUser(userRow)
+    const payload = req.body || {}
+    const name = String(payload.name || userRow.name || (userRow.email ? userRow.email.split('@')[0] : 'Provider'))
+    const data = {
+      name,
+      bio: String(payload.bio || ''),
+      location: String(payload.location || ''),
+      website: String(payload.website || ''),
+      phone: String(payload.phone || ''),
+      specialties: String(payload.specialties || ''),
+      hourlyRate: Number(payload.hourlyRate || 0),
+      availability: String(payload.availability || ''),
+      experienceYears: Number(payload.experienceYears || 0),
+      languages: String(payload.languages || ''),
+      certifications: String(payload.certifications || ''),
+      socialTwitter: String(payload.socialTwitter || ''),
+      socialInstagram: String(payload.socialInstagram || ''),
+      portfolio: String(payload.portfolio || ''),
+      sessionLength: String(payload.sessionLength || ''),
+      editedPhotos: Number(payload.editedPhotos || 0),
+      delivery: String(payload.delivery || ''),
+      turnaround: String(payload.turnaround || ''),
+      onLocation: Boolean(payload.onLocation),
+      studioAvailable: Boolean(payload.studioAvailable),
+      travelRadius: String(payload.travelRadius || ''),
+      styles: String(payload.styles || ''),
+      equipment: String(payload.equipment || ''),
+    }
+    upsertProvider(providerId, data, name)
+    const providerRow = fetchProviderRow(providerId)
+    return res.json({ ...normalizeProvider(providerRow, providerId, name), id: providerId })
+  }
+  const key = decoded.sub || decoded.email || 'anon'
   const prev = traderProfiles.get(key) || {}
   const next = { ...prev, ...req.body }
   traderProfiles.set(key, next)
   res.json(next)
-})
+}
+app.put('/api/trader/profile', requireAuth, writeTraderProfile)
+app.post('/api/trader/profile', requireAuth, writeTraderProfile)
 
 // Conversations API (in-memory demo)
 app.get('/api/conversations', requireAuth, (req, res) => {

--- a/frontend/src/pages/UserDashboard.jsx
+++ b/frontend/src/pages/UserDashboard.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { fetchAuthed } from '../hooks/useAuth.js'
+import { fetchAuthed, setToken } from '../hooks/useAuth.js'
 import { Section, Pill, PlayerBadge, Button, Input } from '../components/ui.js'
 import { Link, useNavigate } from 'react-router-dom'
 
@@ -34,7 +34,21 @@ export default function UserDashboard(){
       <div className="flex items-start justify-between mb-4">
         <h1 className="text-2xl font-semibold">Welcome{me ? `, ${me.name}` : ''}</h1>
         {me && me.role !== 'TRADER' && (
-          <Button onClick={async ()=>{ try{ const r = await fetchAuthed('/api/become-provider', { method:'POST' }); if (r.ok){ window.location.href = '/dashboard/trader' } else { alert('Could not upgrade to provider') } }catch{ alert('Could not upgrade to provider') } }}>Become a provider</Button>
+          <Button onClick={async ()=>{
+            try{
+              const r = await fetchAuthed('/api/become-provider', { method:'POST' })
+              let data = null
+              try{ data = await r.json() }catch{}
+              if (r.ok){
+                if (data?.token) setToken(data.token)
+                window.location.href = '/dashboard/trader'
+              } else {
+                alert((data && (data.error || data.message)) || 'Could not upgrade to provider')
+              }
+            }catch{
+              alert('Could not upgrade to provider')
+            }
+          }}>Become a provider</Button>
         )}
       </div>
 


### PR DESCRIPTION
## Summary
- Sync JWT metadata with persisted user records and enrich `/api/me` responses with names and provider links.
- Serve favorites, history, provider onboarding, and checkout data from SQLite with in-memory fallbacks.
- Calculate trader dashboard stats/profile updates from the database and store refreshed tokens when users become providers.

## Testing
- node --check backend/src/server.js
- npm --prefix backend run seed
- npm --prefix frontend run build

------
https://chatgpt.com/codex/tasks/task_e_68c9b0de4e0c8322ab533dcefafefe61